### PR TITLE
Update docs/version, add CI to verify commits & PRs, and add tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,39 @@
+use std::path::Path;
+
+/// Vendored frontend dependencies that the `serve` command embeds via
+/// `include_str!`. They are downloaded at build time and cached in
+/// `src/assets/serve` (the files are git-ignored).
+const ASSETS: &[(&str, &str)] = &[
+    (
+        "https://unpkg.com/preact?module",
+        "./src/assets/serve/preact.mjs",
+    ),
+    ("https://unpkg.com/htm?module", "./src/assets/serve/htm.mjs"),
+];
+
 fn main() {
-    // Download the preact source from the url
-    let preact_src = reqwest::blocking::get("https://unpkg.com/preact?module")
-        .unwrap()
-        .text()
-        .unwrap();
-    // Write the preact source into a file
-    let _ = std::fs::write("./src/assets/serve/preact.mjs", preact_src);
-    // Download the htm source from the url
-    let htm_src = reqwest::blocking::get("https://unpkg.com/htm?module")
-        .unwrap()
-        .text()
-        .unwrap();
-    // Write the htm source into a file
-    let _ = std::fs::write("./src/assets/serve/htm.mjs", htm_src);
+    for (url, dest) in ASSETS {
+        fetch_asset(url, dest);
+    }
+}
+
+/// Download `url` into `dest`. If the download fails we keep an already cached
+/// copy when present, or fall back to an empty placeholder so that the
+/// `include_str!` calls still compile (e.g. offline builds). This keeps the
+/// build from breaking when unpkg.com is unreachable.
+fn fetch_asset(url: &str, dest: &str) {
+    match reqwest::blocking::get(url).and_then(|response| response.text()) {
+        Ok(body) => {
+            if let Err(error) = std::fs::write(dest, body) {
+                println!("cargo:warning=could not write {dest}: {error}");
+            }
+        }
+        Err(error) => {
+            println!("cargo:warning=could not download {url}: {error}");
+            if !Path::new(dest).exists() {
+                println!("cargo:warning=writing empty placeholder for {dest}");
+                let _ = std::fs::write(dest, "");
+            }
+        }
+    }
 }

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -143,17 +143,8 @@ async fn copy_files(
         let mut to_path = to_path.clone();
         let name = file.name.clone();
         let path = from_path.clone();
-        // If the static_path ends with a / remove it
-        let starting_path = if starting_path.to_str().unwrap().ends_with("/")
-            || starting_path.to_str().unwrap().ends_with("\\")
-        {
-            let mut starting_path = starting_path.to_str().unwrap().to_owned();
-            // Pop returns the last character, so we need to return the whole starting path without the last character
-            starting_path.pop().unwrap();
-            starting_path
-        } else {
-            starting_path.to_str().unwrap().to_string()
-        };
+        // If the starting_path ends with a separator remove it
+        let starting_path = strip_trailing_separator(starting_path.to_str().unwrap()).to_string();
         // Split the to_path and make sure all the folders exist, if not create them
         for folder in from_path
             .parent()
@@ -250,7 +241,7 @@ async fn copy_files(
                     break;
                 }
                 bytes_read = buffer.len();
-                writer_buffer.write(buffer).unwrap();
+                writer_buffer.write_all(buffer).unwrap();
             }
             writer_buffer.flush().unwrap();
             individual_progress.inc(bytes_read as u64);
@@ -277,4 +268,29 @@ async fn copy_files(
         }
     });
     transfering_bar_global.finish_with_message("Done copying files");
+}
+
+/// Remove a single trailing path separator (`/` or `\`) from `path`, if present.
+fn strip_trailing_separator(path: &str) -> &str {
+    path.strip_suffix(['/', '\\']).unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_unix_separator() {
+        assert_eq!(strip_trailing_separator("/home/user/"), "/home/user");
+    }
+
+    #[test]
+    fn strips_windows_separator() {
+        assert_eq!(strip_trailing_separator("C:\\files\\"), "C:\\files");
+    }
+
+    #[test]
+    fn leaves_path_without_separator_untouched() {
+        assert_eq!(strip_trailing_separator("/home/user"), "/home/user");
+    }
 }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -14,25 +14,14 @@ pub async fn entry(url: &str, to: Option<&String>) {
 
     let file_name = match to {
         Some(to) => to.to_string(),
-        None => match response.headers().get("content-disposition") {
-            Some(content_disposition) => content_disposition
-                .to_str()
-                .unwrap()
-                .split("filename=")
-                .collect::<Vec<&str>>()[1]
-                .replace("\"", ""),
-            None => {
-                // If the url ends with a slash, remove it
-                let url = if url.ends_with("/") {
-                    let mut url = url.to_string();
-                    url.pop().unwrap();
-                    url
-                } else {
-                    url.to_string()
-                };
-                let url_split = url.split("/").collect::<Vec<&str>>();
-                url_split[url_split.len() - 1].to_string()
-            }
+        None => match response
+            .headers()
+            .get("content-disposition")
+            .and_then(|value| value.to_str().ok())
+            .and_then(file_name_from_content_disposition)
+        {
+            Some(name) => name,
+            None => file_name_from_url(url),
         },
     };
 
@@ -97,4 +86,71 @@ pub async fn entry(url: &str, to: Option<&String>) {
 
     // Finish the progress bar
     pb.finish_with_message(format!("Downloaded {} to {}", url, file_name));
+}
+
+/// Derive a file name from the last path segment of a URL, ignoring a single
+/// trailing slash.
+fn file_name_from_url(url: &str) -> String {
+    let url = url.strip_suffix('/').unwrap_or(url);
+    match url.rsplit('/').next() {
+        Some(name) if !name.is_empty() => name.to_string(),
+        _ => url.to_string(),
+    }
+}
+
+/// Extract the file name from a `Content-Disposition` header value, if it
+/// contains a `filename=` parameter.
+fn file_name_from_content_disposition(value: &str) -> Option<String> {
+    value
+        .split("filename=")
+        .nth(1)
+        .map(|name| name.trim().replace('\"', ""))
+        .filter(|name| !name.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_name_from_plain_url() {
+        assert_eq!(
+            file_name_from_url("https://example.com/file.zip"),
+            "file.zip"
+        );
+    }
+
+    #[test]
+    fn file_name_from_url_with_trailing_slash() {
+        assert_eq!(
+            file_name_from_url("https://example.com/path/archive.tar.gz/"),
+            "archive.tar.gz"
+        );
+    }
+
+    #[test]
+    fn file_name_from_url_without_path() {
+        assert_eq!(file_name_from_url("https://example.com"), "example.com");
+    }
+
+    #[test]
+    fn content_disposition_with_filename() {
+        assert_eq!(
+            file_name_from_content_disposition("attachment; filename=\"report.pdf\""),
+            Some("report.pdf".to_string())
+        );
+    }
+
+    #[test]
+    fn content_disposition_without_quotes() {
+        assert_eq!(
+            file_name_from_content_disposition("attachment; filename=report.pdf"),
+            Some("report.pdf".to_string())
+        );
+    }
+
+    #[test]
+    fn content_disposition_without_filename() {
+        assert_eq!(file_name_from_content_disposition("inline"), None);
+    }
 }


### PR DESCRIPTION
## Resumen

Actualiza el repositorio (README y versión), añade un pipeline de CI que verifica cada commit y PR, e introduce los primeros tests del proyecto.

## Cambios

### Docs y versión
- Documenta los comandos `httpeek` y `wscat` (estaban implementados pero sin documentar) y el flag `copy --log` en el README; actualiza la lista de utilidades.
- Sube la versión `0.1.0` → `0.2.0` y añade metadata (`description`, `license`, `repository`) en `Cargo.toml`.
- El `--version` del CLI ahora deriva de `CARGO_PKG_VERSION` en vez de estar hardcodeado.

### CI (`.github/workflows/ci.yml`)
- Workflow nuevo que corre **en cada push y en cada pull request**: `cargo fmt --check`, `cargo clippy`, `cargo build` y `cargo test`.
- Incluye caché de cargo y cancelación de runs duplicados.
- El `deploy.yml` existente (release en push a `main`) se mantiene intacto.

### Tests (primeros del proyecto)
- Extrae lógica pura a funciones testeables y la cubre con 9 tests unitarios:
  - `download`: `file_name_from_url` y `file_name_from_content_disposition` (este último evita un posible panic cuando el header no trae `filename=`).
  - `copy`: `strip_trailing_separator`.

### Arreglos de robustez
- `build.rs` ya no aborta el build si falla la descarga de assets desde unpkg.com (conserva la copia cacheada o escribe un placeholder), evitando que el CI falle por una caída del CDN.
- Corrige un lint de correctness de clippy en `copy` (`write` → `write_all`), que también arregla un bug real de copiado parcial.

## Verificación local
```
cargo fmt --all --check    → OK
cargo clippy --all-targets → sin errores
cargo test                 → 9 passed; 0 failed
```

## Nota
También se aplicó `rustfmt` a todo el código (estaba sin formatear) para que el check de formato pase en verde.

https://claude.ai/code/session_019LSMdcbrAXyZbN1RAe52YQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019LSMdcbrAXyZbN1RAe52YQ)_