### PR TITLE
copy: caché de índice opt-in (--index), errores legibles y rutas multiplataforma

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,22 @@ Usage: xyi.exe {copy|--copy|-C} [OPTIONS] --from <from> --to <to>
     -T, --threads <threads>  Number of threads to use
     -H, --hash               Check the hash of the local file and the remote file before copying
     -l, --log <log>          Destination of logs
+    -i, --index <index>      Path to an index cache file
     -h, --help               Print help
 
 ```
+
+#### Index cache
+
+The first thing `copy` does is scan the source tree to build the index of files
+to copy. With `--index <file>` that index is persisted: if the file already
+exists it is reused as-is and the scan is skipped, which speeds up repeated runs
+over a large source tree. Otherwise the freshly scanned index is written there
+for next time.
+
+The cache is trusted as-is and is **not** revalidated against the source, so
+files added to or removed from the source after the index was written will not
+be detected. Delete the index file to force a fresh scan.
 
 ### serve
 

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -8,6 +8,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use seahash::hash;
 
+#[derive(serde::Serialize, serde::Deserialize)]
 struct FilesSource {
     path: std::path::PathBuf,
     name: String,
@@ -50,6 +51,7 @@ pub async fn entry(
     hash_check: bool,
     continue_on_error: bool,
     log_path: Option<String>,
+    index_path: Option<String>,
 ) {
     // Create a new group of progress bars
     let bar = MultiProgress::new();
@@ -64,7 +66,20 @@ pub async fn entry(
 
     let from_path = std::path::PathBuf::from(from);
     let to_path = std::path::PathBuf::from(to);
-    let files = scan_for_files_to_copy(from_path.clone(), &folder_bar).await;
+    // Reuse a cached index when one is available, otherwise scan the source tree
+    // and persist the result for the next run. The cache is trusted as-is and is
+    // never revalidated against the source, so files added or removed after it
+    // was written will not be picked up until the index file is deleted.
+    let files = match index_path.as_ref().and_then(|path| load_index(path, &folder_bar)) {
+        Some(files) => files,
+        None => {
+            let files = scan_for_files_to_copy(from_path.clone(), &folder_bar).await;
+            if let Some(path) = index_path.as_ref() {
+                save_index(&files, path);
+            }
+            files
+        }
+    };
 
     // Create a new progress bar for copying the files
     let transfering_bar = bar.add(ProgressBar::new(files.len() as u64));
@@ -143,6 +158,30 @@ async fn scan_for_files_to_copy(
     // End the progress bar
     scanning_bar.finish_with_message(format!("Done reading {} files", files.len()));
     files
+}
+
+/// Load a previously persisted copy index from `path`. Returns `None` when the
+/// file does not exist or cannot be parsed so the caller can fall back to a
+/// fresh scan. The cache is trusted as-is and is intentionally not revalidated
+/// against the source tree.
+fn load_index(path: &str, scanning_bar: &ProgressBar) -> Option<Vec<FilesSource>> {
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let files: Vec<FilesSource> = serde_json::from_reader(reader).ok()?;
+    scanning_bar.finish_with_message(format!("Loaded {} files from index cache", files.len()));
+    Some(files)
+}
+
+/// Persist the scanned copy index to `path` so subsequent runs can skip the
+/// recursive directory scan via `--index`. A failure to write the cache is
+/// non-fatal: the copy has all the information it needs in memory already.
+fn save_index(files: &[FilesSource], path: &str) {
+    let file = match File::create(path) {
+        Ok(file) => file,
+        Err(_) => return,
+    };
+    let writer = BufWriter::new(file);
+    let _ = serde_json::to_writer(writer, files);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -70,7 +70,10 @@ pub async fn entry(
     // and persist the result for the next run. The cache is trusted as-is and is
     // never revalidated against the source, so files added or removed after it
     // was written will not be picked up until the index file is deleted.
-    let files = match index_path.as_ref().and_then(|path| load_index(path, &folder_bar)) {
+    let files = match index_path
+        .as_ref()
+        .and_then(|path| load_index(path, &folder_bar))
+    {
         Some(files) => files,
         None => {
             let files = match scan_for_files_to_copy(from_path.clone(), &folder_bar).await {

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -73,7 +73,18 @@ pub async fn entry(
     let files = match index_path.as_ref().and_then(|path| load_index(path, &folder_bar)) {
         Some(files) => files,
         None => {
-            let files = scan_for_files_to_copy(from_path.clone(), &folder_bar).await;
+            let files = match scan_for_files_to_copy(from_path.clone(), &folder_bar).await {
+                Ok(files) => files,
+                Err(error) => {
+                    folder_bar.abandon_with_message("Scan aborted due to an error");
+                    eprintln!(
+                        "\nScan aborted: failed to read '{}': {}",
+                        error.path.display(),
+                        error.message
+                    );
+                    std::process::exit(1);
+                }
+            };
             if let Some(path) = index_path.as_ref() {
                 save_index(&files, path);
             }
@@ -85,16 +96,20 @@ pub async fn entry(
     let transfering_bar = bar.add(ProgressBar::new(files.len() as u64));
     transfering_bar.set_style(style_files_transfering.clone());
 
-    // Create a log writer
+    // Create a log writer. Logging is a convenience, not a requirement, so a
+    // failure to open the log file warns the user and carries on instead of
+    // aborting the whole copy.
     let log_writer = match log_path {
-        Some(path) => {
-            let file = OpenOptions::new()
-                .write(true)
-                .append(true)
-                .open(path)
-                .unwrap();
-            Some(Mutex::new(file))
-        }
+        Some(path) => match OpenOptions::new().write(true).append(true).open(&path) {
+            Ok(file) => Some(Mutex::new(file)),
+            Err(error) => {
+                eprintln!(
+                    "Warning: could not open log file '{}': {}. Continuing without logging.",
+                    path, error
+                );
+                None
+            }
+        },
         None => None,
     };
 
@@ -114,17 +129,25 @@ pub async fn entry(
     .await;
 }
 
-async fn scan_for_files_to_copy(
-    entry_path: std::path::PathBuf,
+/// Read a single directory into its files and sub-folders, turning any I/O
+/// problem into a [`CopyError`] with a human readable message instead of
+/// panicking. File names are decoded lossily so non-UTF-8 names (common on
+/// Windows) never abort the scan.
+fn read_dir_into(
+    dir: &std::path::Path,
+    files: &mut Vec<FilesSource>,
+    folders: &mut Vec<FoldersSource>,
     scanning_bar: &ProgressBar,
-) -> Vec<FilesSource> {
-    let mut files: Vec<FilesSource> = vec![];
-    let mut folders: Vec<FoldersSource> = vec![];
-    // Scan all the files and folders in the current directory
-    for entry in std::fs::read_dir(entry_path).unwrap() {
-        let entry = entry.unwrap();
+) -> Result<(), CopyError> {
+    let entries = std::fs::read_dir(dir).map_err(|error| {
+        CopyError::new(dir, format!("could not read source directory: {}", error))
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            CopyError::new(dir, format!("could not read a directory entry: {}", error))
+        })?;
         let path = entry.path();
-        let name = entry.file_name().into_string().unwrap();
+        let name = entry.file_name().to_string_lossy().into_owned();
         scanning_bar.set_message(format!("Reading {}", name));
         if path.is_dir() {
             folders.push(FoldersSource { path });
@@ -132,23 +155,32 @@ async fn scan_for_files_to_copy(
             files.push(FilesSource { path, name });
         }
     }
+    Ok(())
+}
+
+/// Recursively scan `entry_path`, returning the list of files to copy. Any
+/// directory that cannot be read aborts the scan with a [`CopyError`] so the
+/// caller can report a clear message instead of crashing with a backtrace.
+async fn scan_for_files_to_copy(
+    entry_path: std::path::PathBuf,
+    scanning_bar: &ProgressBar,
+) -> Result<Vec<FilesSource>, CopyError> {
+    let mut files: Vec<FilesSource> = vec![];
+    let mut folders: Vec<FoldersSource> = vec![];
+    // Scan all the files and folders in the current directory
+    read_dir_into(&entry_path, &mut files, &mut folders, scanning_bar)?;
     loop {
-        if folders.len() == 0 {
+        if folders.is_empty() {
             break;
         }
         let mut folders_to_travel: Vec<FoldersSource> = vec![];
         for folder in folders.clone() {
-            for entry in std::fs::read_dir(&folder.path).unwrap() {
-                let entry = entry.unwrap();
-                let path = entry.path();
-                let name = entry.file_name().into_string().unwrap();
-                scanning_bar.set_message(format!("Reading {}", name));
-                if path.is_dir() {
-                    folders_to_travel.push(FoldersSource { path });
-                } else {
-                    files.push(FilesSource { path, name });
-                }
-            }
+            read_dir_into(
+                &folder.path,
+                &mut files,
+                &mut folders_to_travel,
+                scanning_bar,
+            )?;
         }
         // Empty the folders vector
         folders.clear();
@@ -157,31 +189,71 @@ async fn scan_for_files_to_copy(
     }
     // End the progress bar
     scanning_bar.finish_with_message(format!("Done reading {} files", files.len()));
-    files
+    Ok(files)
 }
 
 /// Load a previously persisted copy index from `path`. Returns `None` when the
-/// file does not exist or cannot be parsed so the caller can fall back to a
-/// fresh scan. The cache is trusted as-is and is intentionally not revalidated
-/// against the source tree.
+/// index cannot be used so the caller can fall back to a fresh scan. A missing
+/// file is the normal "first run" case and is silent; anything else (an
+/// unreadable or corrupt cache) is reported to the user as a warning before
+/// falling back. The cache is trusted as-is and is intentionally not
+/// revalidated against the source tree.
 fn load_index(path: &str, scanning_bar: &ProgressBar) -> Option<Vec<FilesSource>> {
-    let file = File::open(path).ok()?;
+    if !std::path::Path::new(path).exists() {
+        // No cache yet: the scan will create it. Nothing to warn about.
+        return None;
+    }
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) => {
+            // Use eprintln! rather than the progress bar so the warning still
+            // reaches the user when output is piped or redirected to a file.
+            eprintln!(
+                "Warning: could not open index cache '{}': {}. Scanning the source instead.",
+                path, error
+            );
+            return None;
+        }
+    };
     let reader = BufReader::new(file);
-    let files: Vec<FilesSource> = serde_json::from_reader(reader).ok()?;
-    scanning_bar.finish_with_message(format!("Loaded {} files from index cache", files.len()));
-    Some(files)
+    match serde_json::from_reader::<_, Vec<FilesSource>>(reader) {
+        Ok(files) => {
+            scanning_bar
+                .finish_with_message(format!("Loaded {} files from index cache", files.len()));
+            Some(files)
+        }
+        Err(error) => {
+            eprintln!(
+                "Warning: index cache '{}' is not valid ({}). Scanning the source instead.",
+                path, error
+            );
+            None
+        }
+    }
 }
 
 /// Persist the scanned copy index to `path` so subsequent runs can skip the
 /// recursive directory scan via `--index`. A failure to write the cache is
-/// non-fatal: the copy has all the information it needs in memory already.
+/// non-fatal: the copy has all the information it needs in memory already, so we
+/// just warn the user that the cache was not saved and carry on.
 fn save_index(files: &[FilesSource], path: &str) {
     let file = match File::create(path) {
         Ok(file) => file,
-        Err(_) => return,
+        Err(error) => {
+            eprintln!(
+                "Warning: could not create index cache '{}': {}. The index was not saved.",
+                path, error
+            );
+            return;
+        }
     };
     let writer = BufWriter::new(file);
-    let _ = serde_json::to_writer(writer, files);
+    if let Err(error) = serde_json::to_writer(writer, files) {
+        eprintln!(
+            "Warning: could not write index cache '{}': {}. The index was not saved.",
+            path, error
+        );
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -289,18 +361,17 @@ fn copy_single_file(
     let mut to_path = to_path.to_path_buf();
     let name = file.name.clone();
     let path = from_path.clone();
-    // If the starting_path ends with a separator remove it
-    let starting_path = strip_trailing_separator(starting_path.to_str().unwrap()).to_string();
-    // Split the to_path and make sure all the folders exist, if not create them
-    for folder in from_path
+    // Mirror the file's directory structure under the destination. We compute
+    // the file's parent directory relative to the source root and walk its
+    // components, creating each level as needed. Working on path components
+    // (instead of splitting a string on a hard-coded separator) keeps this
+    // correct on both Windows (`\`) and Unix (`/`) and avoids panicking on
+    // non-UTF-8 paths.
+    let parent = from_path
         .parent()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .replace(&starting_path, "")
-        .split('\\')
-        .collect::<Vec<&str>>()
-    {
+        .unwrap_or_else(|| std::path::Path::new(""));
+    let relative = relative_dir(parent, starting_path);
+    for folder in relative.components() {
         to_path = to_path.join(folder);
         if !to_path.exists() {
             // Creating an already existing directory races harmlessly between
@@ -432,8 +503,8 @@ fn copy_single_file(
             let _ = log_writer.write_all(
                 format!(
                     "- Copied {} to {} - at {}\n",
-                    from_path.to_str().unwrap(),
-                    to_path.to_str().unwrap(),
+                    from_path.display(),
+                    to_path.display(),
                     date
                 )
                 .as_bytes(),
@@ -446,27 +517,46 @@ fn copy_single_file(
     outcome
 }
 
-/// Remove a single trailing path separator (`/` or `\`) from `path`, if present.
-fn strip_trailing_separator(path: &str) -> &str {
-    path.strip_suffix(['/', '\\']).unwrap_or(path)
+/// Compute `parent` relative to the source `root` so the directory structure
+/// can be recreated under the destination. When `parent` does not live under
+/// `root` (for instance when an index built from a different source is reused)
+/// the parent is returned unchanged. Comparison is done on whole path
+/// components, so a trailing separator on `root` is irrelevant and both Windows
+/// and Unix separators are handled natively.
+fn relative_dir<'a>(parent: &'a std::path::Path, root: &std::path::Path) -> &'a std::path::Path {
+    parent.strip_prefix(root).unwrap_or(parent)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
 
     #[test]
-    fn strips_unix_separator() {
-        assert_eq!(strip_trailing_separator("/home/user/"), "/home/user");
+    fn relative_dir_strips_the_source_root() {
+        let parent = PathBuf::from("/data/src/a/b");
+        let root = Path::new("/data/src");
+        assert_eq!(relative_dir(&parent, root), Path::new("a/b"));
     }
 
     #[test]
-    fn strips_windows_separator() {
-        assert_eq!(strip_trailing_separator("C:\\files\\"), "C:\\files");
+    fn relative_dir_ignores_trailing_separator_on_root() {
+        let parent = PathBuf::from("/data/src/a");
+        let root = Path::new("/data/src/");
+        assert_eq!(relative_dir(&parent, root), Path::new("a"));
     }
 
     #[test]
-    fn leaves_path_without_separator_untouched() {
-        assert_eq!(strip_trailing_separator("/home/user"), "/home/user");
+    fn relative_dir_is_empty_for_files_in_the_root() {
+        let parent = PathBuf::from("/data/src");
+        let root = Path::new("/data/src");
+        assert_eq!(relative_dir(&parent, root), Path::new(""));
+    }
+
+    #[test]
+    fn relative_dir_falls_back_when_not_under_root() {
+        let parent = PathBuf::from("/somewhere/else");
+        let root = Path::new("/data/src");
+        assert_eq!(relative_dir(&parent, root), Path::new("/somewhere/else"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,14 @@ async fn main() {
                         .help("Destination of logs")
                         .required(false)
                         .num_args(1),
+                )
+                .arg(
+                    Arg::new("index")
+                        .short('i')
+                        .long("index")
+                        .help("Path to an index cache file: reused as-is if it exists (skips the source scan), otherwise the scan result is written there for next time")
+                        .required(false)
+                        .num_args(1),
                 ),
         )
         .subcommand(
@@ -247,6 +255,9 @@ async fn main() {
                 }
                 None => None,
             };
+            let index = copy_match
+                .get_one::<String>("index")
+                .map(|index| index.to_string());
             env::set_var("RAYON_NUM_THREADS", threads.to_string());
             commands::copy::entry(
                 from.to_string(),
@@ -256,6 +267,7 @@ async fn main() {
                 hash_check,
                 continue_on_error,
                 logs,
+                index,
             )
             .await;
         }


### PR DESCRIPTION
## Resumen

Este PR mejora el comando `copy` en tres frentes: añade una **caché de índice opcional**, hace que los **errores sean legibles** en vez de panics/silencios, y corrige el **manejo de rutas para que funcione en Unix además de Windows**.

---

## 1. Caché de índice opt-in (`--index`)

Lo primero que hace `copy` es escanear recursivamente el origen para construir la lista de ficheros a copiar. En re-ejecuciones repetidas sobre un árbol grande y estable, ese escaneo se repite innecesariamente.

Con el nuevo flag `-i, --index <fichero>`:

- Si el fichero **no existe** → se escanea el origen y el índice resultante se **guarda** ahí (en JSON, vía `serde_json`).
- Si el fichero **existe** → se **carga** y se **salta el escaneo** entero.

### Decisión de diseño: la caché se confía sin revalidar

La caché se reutiliza **tal cual**, sin compararla contra el origen. El motivo: revalidar el árbol implicaría volver a hacer el `read_dir` recursivo, que es justo lo que se quería ahorrar. Como contrapartida:

- Ficheros **añadidos** al origen tras generar el índice → no se copian.
- Ficheros **borrados** → seguirán en el índice.

Para forzar un re-escaneo basta con **borrar el fichero de índice**. Está documentado en el README.

> **Nota sobre el alcance del ahorro:** el escaneo es solo metadatos (`read_dir`); el coste real de una copia está en leer/escribir contenido y, sobre todo, en `--hash`. Esta caché ayuda en el caso concreto de muchas re-ejecuciones sobre un árbol grande y estable. Una caché de *hashes* (que aceleraría `--hash`) sería una mejora distinta y mayor, no incluida aquí.

---

## 2. Errores legibles para el usuario

Antes había varios `.unwrap()` que abortaban con un panic + backtrace, y el código de caché se tragaba los errores en silencio. Ahora:

- **Escaneo:** si el origen no existe o no se puede leer, aborta con un mensaje claro (`Scan aborted: failed to read '<ruta>': <motivo>`) en lugar de un panic.
- **Caché de índice:** si está corrupta, es ilegible o no se puede escribir, se emite un `Warning: ...` y se cae limpiamente a un escaneo fresco. Los avisos usan `eprintln!` en vez de la barra de progreso **a propósito**: `indicatif` suprime la salida de la barra cuando no hay TTY (salida redirigida a fichero o pipe), que es justo donde el usuario querría ver el aviso.
- **Log:** si el fichero de log no se puede abrir, avisa y **continúa** la copia (el log es accesorio, no debe abortar el trabajo).

---

## 3. Rutas multiplataforma

La reconstrucción de directorios en el destino partía las rutas **solo por `'\\'`** (separador de Windows). En **Unix las subcarpetas anidadas fallaban** con `could not create destination directory`, porque la ruta relativa completa (`a/b/c`) se trataba como un único segmento y no se creaban los niveles intermedios.

Reescrito con `Path::strip_prefix` + `components()`:

- Funciona nativamente en **Windows (`\`)** y **Unix (`/`)**, sin separadores hardcodeados.
- Un separador final en el origen ya no importa (la comparación es por componentes), así que se eliminó el helper `strip_trailing_separator`.
- De paso se quitaron los `to_str().unwrap()`, que **panicaban con rutas no-UTF8** (frecuentes en Windows): los nombres de fichero ahora se decodifican con `to_string_lossy()` y las líneas de log usan `Path::display()`.

---

## Pruebas

- `cargo build` y `cargo test` en verde (**10 tests**).
- Se sustituyeron los tests de `strip_trailing_separator` (helper eliminado) por 4 tests de `relative_dir`: strip del root, separador final en el root, fichero directamente en la raíz, y fallback cuando la ruta no cuelga del root.
- Verificación manual:
  - Copia con anidamiento `src/a/b/c/f3.txt` → `dst/a/b/c/f3.txt` (antes abortaba en Unix).
  - Reutilización de índice: segunda ejecución muestra `Loaded N files from index cache` en vez de re-escanear.
  - Origen inexistente → `Scan aborted: ...` (sin panic).
  - Índice corrupto / no escribible → `Warning: ...` visible incluso con la salida redirigida.

## Documentación

`README.md` actualizado con el flag `--index` y una sección explicando la caché y su comportamiento de no-revalidación.

https://claude.ai/code/session_01AifbFE9a9aGbVoaUsA4L4g

---
_Generated by [Claude Code](https://claude.ai/code/session_01AifbFE9a9aGbVoaUsA4L4g)_