### PR TITLE
serve: add download-all-as-zip button and redesign UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +555,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1109,6 +1134,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1772,6 +1807,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2819,6 +2860,7 @@ dependencies = [
  "tower-http",
  "tracing-subscriber",
  "tungstenite",
+ "zip",
 ]
 
 [[package]]
@@ -2916,6 +2958,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tungstenite = {version = "0.20.0", features = ["rustls"]}
 tower = "0.4"
 tower-http = { version = "0.4", features = ["fs"] }
 chrono = "0.4.35"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [build-dependencies]
 reqwest = {version = "0.11.18", features=["blocking", "rustls-tls"], default-features = false}

--- a/src/assets/serve/index.html
+++ b/src/assets/serve/index.html
@@ -1,44 +1,166 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Serve xyi command</title>
+    <title>xyi // serve</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
+      :root {
+        --bg: #050505;
+        --panel: #0b0b0b;
+        --line: #f5f5f5;
+        --muted: #7f7f7f;
+        --positive: #5ee06c;
+        --warning: #ffd24a;
+        --critical: #ff5d5d;
+      }
+      * {
+        box-sizing: border-box;
+      }
       body {
-        font-family: sans-serif;
         margin: 0;
-        padding: 1rem;
-        background-color: #e7ecef;
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--line);
+        font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, monospace;
+        padding: 20px;
       }
-
-      .divider {
-        border-bottom: 3px solid black;
-        margin: 10px 0;
+      .screen {
+        max-width: 1100px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
       }
-
-      ul {
-        list-style: outside;
-        padding: 1rem;
-        padding-left: 2rem;
-        margin: 0.5rem;
-        transition: all 0.2s ease-in-out;
-        /* Create a rounded border with shadow */
-        border-radius: 10px;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.368);
-        background-color: white;
-        /* Reduce margin when on mobile */
+      .panel {
+        border: 1px dashed rgba(245, 245, 245, 0.7);
+        background: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.03),
+          rgba(255, 255, 255, 0.01)
+        );
+        padding: 16px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
       }
-      @media (min-width: 768px) {
-        ul {
-          margin: 5rem;
-        }
+      .panel h1,
+      .panel h2,
+      .panel p {
+        margin: 0;
       }
-
-      li {
-        padding: 10px 0px;
-        margin: 0.5rem;
+      .eyebrow {
+        color: var(--muted);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .header-row {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+      h1 {
+        font-size: 28px;
+        letter-spacing: 0.04em;
+      }
+      .path {
+        color: var(--muted);
+        font-size: 13px;
+        word-break: break-all;
+      }
+      .path span {
+        color: var(--line);
+      }
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--muted);
+      }
+      .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: var(--warning);
+        box-shadow: 0 0 8px currentColor;
+      }
+      .dot.online {
+        background: var(--positive);
+      }
+      .btn {
+        border: 1px solid rgba(245, 245, 245, 0.75);
+        background: transparent;
+        color: var(--line);
+        font-family: inherit;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 9px 16px;
         cursor: pointer;
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        transition: all 0.15s ease-in-out;
+      }
+      .btn:hover {
+        background: var(--line);
+        color: var(--bg);
+      }
+      .list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      .list li {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 11px 4px;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        cursor: pointer;
+        transition: background 0.12s ease-in-out;
+      }
+      .list li:first-child {
+        border-top: none;
+      }
+      .list li:hover {
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .list a {
+        color: var(--line);
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        width: 100%;
+      }
+      .glyph {
+        color: var(--muted);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        min-width: 38px;
+      }
+      .folder .glyph {
+        color: var(--warning);
+      }
+      .file .glyph {
+        color: var(--positive);
       }
     </style>
     <script type="module">
@@ -73,50 +195,74 @@
       let ws_updator = new WebSocket(url.href);
 
       function App(props) {
-        return html`<div>
-          <h1>Current dir: ${props.data.current_dir}</h1>
-          <div class="divider"></div>
-          <ul>
-            <li
-              onclick=${() =>
-                ws_updator.send(
-                  JSON.stringify({ message_type: "up_dir", message: "" })
-                )}
-            >
-              📁 ..
-            </li>
-            ${props.data.folders.map(
-              (folder) =>
-                html`<li
-                  onclick=${() => {
-                    ws_updator.send(
-                      JSON.stringify({
-                        message_type: "change_dir",
-                        message: folder.path,
-                      })
-                    );
-                  }}
-                >
-                  📁 ${folder.name}
-                </li>`
-            )}
-            ${props.data.files.map(
-              (file) =>
-                html`<li>
-                  <a
-                    target="_blank"
-                    href=${new URL(
-                      "/download?path=" + btoa(file.path),
-                      window.location.href
-                    )}
-                    >📋 ${file.name}
-                  </a>
-                </li>`
-            )}
-          </ul>
-          <div class="divider"></div>
-          <h3>Socket connected: ${socket_connected ? "🟢" : "🟡"}</h3>
-        </div> `;
+        return html`<main class="screen">
+          <section class="panel">
+            <div class="header-row">
+              <div>
+                <div class="eyebrow">xyi / serve</div>
+                <h1>File Server</h1>
+              </div>
+              <div class="toolbar">
+                <span class="status">
+                  <span class="dot ${props.status ? "online" : ""}"></span>
+                  ${props.status ? "connected" : "reconnecting"}
+                </span>
+                <a class="btn" href=${new URL("/download_zip", window.location.href)}>
+                  ⤓ Download all (.zip)
+                </a>
+              </div>
+            </div>
+            <p class="path">serving · <span>${props.data.current_dir}</span></p>
+          </section>
+
+          <section class="panel">
+            <div class="eyebrow">Directory listing</div>
+            <ul class="list">
+              <li
+                class="folder"
+                onclick=${() =>
+                  ws_updator.send(
+                    JSON.stringify({ message_type: "up_dir", message: "" })
+                  )}
+              >
+                <span class="glyph">dir</span>
+                ..
+              </li>
+              ${props.data.folders.map(
+                (folder) =>
+                  html`<li
+                    class="folder"
+                    onclick=${() => {
+                      ws_updator.send(
+                        JSON.stringify({
+                          message_type: "change_dir",
+                          message: folder.path,
+                        })
+                      );
+                    }}
+                  >
+                    <span class="glyph">dir</span>
+                    ${folder.name}
+                  </li>`
+              )}
+              ${props.data.files.map(
+                (file) =>
+                  html`<li class="file">
+                    <a
+                      target="_blank"
+                      href=${new URL(
+                        "/download?path=" + btoa(file.path),
+                        window.location.href
+                      )}
+                    >
+                      <span class="glyph">file</span>
+                      ${file.name}
+                    </a>
+                  </li>`
+              )}
+            </ul>
+          </section>
+        </main>`;
       }
 
       ws.onmessage = (ev) => {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -254,8 +254,8 @@ async fn download_zip(State(state): State<AppState>) -> impl IntoResponse {
 fn zip_directory(root: &std::path::Path) -> std::io::Result<(Vec<u8>, String)> {
     let buffer = std::io::Cursor::new(Vec::new());
     let mut zip = zip::ZipWriter::new(buffer);
-    let options = zip::write::FileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated);
+    let options =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     add_dir_to_zip(&mut zip, root, root, options)?;
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -73,6 +73,7 @@ pub async fn entry(port: &str, starting_dir: &str) {
         .route("/state", get(ws))
         .route("/update_state", get(ws_change))
         .route("/download", get(download_file))
+        .route("/download_zip", get(download_zip))
         .route("/preact.mjs", get(download_preact_mjs))
         .route("/htm.mjs", get(download_htm_mjs))
         .with_state(shared_state);
@@ -213,6 +214,88 @@ async fn download_file(
 
     let serve_file = tower_http::services::fs::ServeFile::new(&path);
     Ok(serve_file.oneshot(request).await)
+}
+
+async fn download_zip(State(state): State<AppState>) -> impl IntoResponse {
+    // Snapshot the directory currently being served.
+    let root = {
+        let current_dir = state.current_dir.lock().unwrap();
+        current_dir.clone()
+    };
+
+    // Building the zip is blocking IO, so keep it off the async executor.
+    let result = tokio::task::spawn_blocking(move || zip_directory(&root)).await;
+
+    match result {
+        Ok(Ok((bytes, name))) => Response::builder()
+            .header("content-type", "application/zip")
+            .header(
+                "content-disposition",
+                format!("attachment; filename=\"{}.zip\"", name),
+            )
+            .body(Body::from(bytes))
+            .unwrap()
+            .into_response(),
+        Ok(Err(err)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to build zip: {}", err),
+        )
+            .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to build zip: {}", err),
+        )
+            .into_response(),
+    }
+}
+
+/// Recursively zip every file under `root`, returning the archive bytes together
+/// with a name suitable for the downloaded file.
+fn zip_directory(root: &std::path::Path) -> std::io::Result<(Vec<u8>, String)> {
+    let buffer = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(buffer);
+    let options = zip::write::FileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    add_dir_to_zip(&mut zip, root, root, options)?;
+
+    let cursor = zip.finish()?;
+    let name = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("root")
+        .to_owned();
+
+    Ok((cursor.into_inner(), name))
+}
+
+fn add_dir_to_zip<W: std::io::Write + std::io::Seek>(
+    zip: &mut zip::ZipWriter<W>,
+    base: &std::path::Path,
+    dir: &std::path::Path,
+    options: zip::write::FileOptions,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let relative = match path.strip_prefix(base) {
+            Ok(relative) => relative,
+            Err(_) => continue,
+        };
+        // Zip archives always use forward slashes for entry names.
+        let name = relative.to_string_lossy().replace('\\', "/");
+
+        if path.is_dir() {
+            zip.add_directory(format!("{}/", name), options)?;
+            add_dir_to_zip(zip, base, &path, options)?;
+        } else {
+            zip.start_file(name, options)?;
+            let mut file = std::fs::File::open(&path)?;
+            std::io::copy(&mut file, zip)?;
+        }
+    }
+    Ok(())
 }
 
 async fn download_preact_mjs() -> impl IntoResponse {


### PR DESCRIPTION
Add a /download_zip endpoint that recursively archives the directory
currently being served and streams it as a single .zip attachment, plus
a "Download all" button in the file browser.

Restyle the serve UI to follow the the-watch design language: dark
background, monospace type, dashed-border panels, uppercase eyebrow
labels and the shared positive/warning/critical state palette.